### PR TITLE
add flag for other img formats

### DIFF
--- a/cog/commands/calibrate.py
+++ b/cog/commands/calibrate.py
@@ -8,6 +8,7 @@ def calibrate(
     phi,
     geometry,
     pathToImages,
+    format="RayonixMX340",
     resolution=2.0,
     spot_profile=(6, 4, 4),
     inpfile="calibrate.inp",
@@ -27,6 +28,8 @@ def calibrate(
         Experimental geometry from which to initialize refinement
     pathToImages : str
         Path to directory containing the MCCD images
+    format  : string (optional)
+        Image format to use by Precognition 
     resolution : float
         High-resolution limit in angstroms
     spot_profile : tuple(length, width, sigma-cut)
@@ -60,7 +63,7 @@ def calibrate(
         f"Input\n"
         f"   Crystal    0.05 0.05 0.05 0.05 0.05 0.05 free\n"
         f"   Distance   0.05 free\n"
-        f"   Format     RayonixMX340\n"
+        f"   Format     {format}\n"
         f"   Resolution {resolution} 100\n"
         f"   Wavelength 1.02 1.18\n"
         f"   Spot       {spot_profile[0]} {spot_profile[1]} {spot_profile[2]}\n"

--- a/cog/commands/index.py
+++ b/cog/commands/index.py
@@ -9,6 +9,7 @@ def index(
     spacegroup=None,
     distance=None,
     center=None,
+    format="RayonixMX340",
     phi=0.0,
     resolution=2.0,
     spot_profile=(6, 4, 4),
@@ -34,6 +35,8 @@ def index(
         Detector distance in mm
     center : tuple(center_x, center_y)
         Coordinates of beam center in pixels
+    format  : string (optional)
+        Image format to use by Precognition 
     phi : float
         Phi angle of goniometer
     resolution : float
@@ -79,7 +82,7 @@ def index(
         f"   Pixel      0.08854 0.08854\n"
         f"   Omega      0 0\n"
         f"   Goniometer 0 0 {phi}\n"
-        f"   Format     RayonixMX340\n"
+        f"   Format     {format}\n"
         f"{matrixline}"
         f"   Image      {image}\n"
         f"   Resolution {resolution:.2f} 100\n"

--- a/cog/commands/refine.py
+++ b/cog/commands/refine.py
@@ -9,6 +9,7 @@ def refine(
     phi,
     geometry,
     pathToImages,
+    format="RayonixMX340",
     resolution=2.0,
     spot_profile=(6, 4, 4),
     inpfile="refine.inp",
@@ -28,6 +29,8 @@ def refine(
         Experimental geometry from which to initialize refinement
     pathToImages : str
         Path to directory containing the MCCD images
+    format  : string (optional)
+        Image format to use by Precognition 
     resolution : float
         High-resolution limit in angstroms
     spot_profile : tuple(length, width, sigma-cut)
@@ -61,7 +64,7 @@ def refine(
         f"Input\n"
         f"   Crystal    0.05 0.05 0.05 0.05 0.05 0.05 free\n"
         f"   Distance   0.05 free\n"
-        f"   Format     RayonixMX340\n"
+        f"   Format     {format}\n"
         f"   Omega      0 0\n"
         f"   prompt off\n"
         f"   result off\n\n"

--- a/cog/commands/softlimits.py
+++ b/cog/commands/softlimits.py
@@ -8,6 +8,7 @@ def softlimits(
     spacegroup=None,
     distance=None,
     center=None,
+    format="RayonixMX340",
     resolution=2.0,
     spot_profile=(10, 5, 2.0),
     inpfile="limits.inp",
@@ -31,6 +32,8 @@ def softlimits(
         Detector distance in mm
     center : tuple(center_x, center_y)
         Coordinates of beam center in pixels
+    format  : string (optional)
+        Image format to use by Precognition 
     resolution : float
         High-resolution limit in angstroms
     spot_profile : tuple(length, width, sigma-cut)
@@ -62,7 +65,7 @@ def softlimits(
         f"   Pixel      0.0886 0.0886\n"
         f"   Omega      0 0\n"
         f"   Goniometer 0 0 0\n"
-        f"   Format     RayonixMX340\n"
+        f"   Format     {format}\n"
         f"   Image      {image}\n"
         f"   Resolution {resolution:.2f} 100\n"
         f"   Wavelength 1.02 1.16\n"

--- a/cog/core/experiment.py
+++ b/cog/core/experiment.py
@@ -362,6 +362,7 @@ class Experiment:
             self.spacegroup,
             self.distance,
             self.center,
+            self.format,
             resolution,
             spot_profile,
         )
@@ -447,7 +448,7 @@ class Experiment:
             raise KeyError(f"{image} was not found in image DataFrame")
 
         rmsd, numMatched, geom = refine(
-            image, phi, geometry, self.pathToImages, resolution, spot_profile
+            image, phi, geometry, self.pathToImages, self.format, resolution, spot_profile
         )
         self.images.loc[image, "geometry"] = geom
         self.images.loc[image, "rmsd"] = rmsd
@@ -478,7 +479,7 @@ class Experiment:
             raise KeyError(f"{image} was not found in image DataFrame")
 
         rmsd, numMatched, geom = calibrate(
-            image, phi, geometry, self.pathToImages, resolution, spot_profile
+            image, phi, geometry, self.pathToImages, self.format, resolution, spot_profile
         )
         self.images.loc[image, "geometry"] = geom
         self.images.loc[image, "rmsd"] = rmsd

--- a/cog/core/experiment.py
+++ b/cog/core/experiment.py
@@ -23,6 +23,7 @@ class Experiment:
         pixelSize=(0.08854, 0.08854),
         cell=None,
         spacegroup=None,
+        format="RayonixMX340",
     ):
 
         # Initialize attributes
@@ -33,7 +34,7 @@ class Experiment:
         self.pixelSize = pixelSize
         self.cell = cell
         self.spacegroup = spacegroup
-
+        self.format = format
         return
 
     # -------------------------------------------------------------------#
@@ -143,6 +144,16 @@ class Experiment:
         Number of images in Experiment
         """
         return len(self.images)
+
+    @property
+    def format(self):
+        """Image format to use by Precognition"""
+        return self._format
+
+    @format.setter
+    def format(self, val):
+        self._format = val
+
 
     # ----------------------------------------------------------------------#
     # Methods
@@ -393,6 +404,7 @@ class Experiment:
             self.spacegroup,
             self.distance,
             self.center,
+            self.format,
             phi,
             resolution,
             spot_profile,


### PR DESCRIPTION
I added an argument when creating an experiment to allow for image formats other than the standard Rayonix format, e.g. the old MarCCD format.